### PR TITLE
dotnet nuget push --timeout description's correction

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -90,7 +90,7 @@ Polecenie wypycha istniejący pakiet. Nie tworzy pakietu. Aby utworzyć pakiet, 
 
 - **`-t|--timeout <TIMEOUT>`**
 
-  Określa limit czasu wypychania do serwera w sekundach. Wartość domyślna to 300 sekund (5 minut). Wartość domyślna to 0 (zero sekund).
+  Określa limit czasu wypychania do serwera w sekundach. Wartość domyślna to 300 sekund (5 minut). Podanie wartości 0 (zero sekund) powoduje ustawienie wartości domyślnej.
 
 ## <a name="examples"></a>Przykłady
 


### PR DESCRIPTION
This pull request fixes #206 

It implements the correction of polish translation of [dotnet nuget push](https://docs.microsoft.com/pl-pl/dotnet/core/tools/dotnet-nuget-push) `-t|--timeout` parameter.

---

The correction changes the last sentence of the description.
The original description had it described as 0 to be default value (repeat of 300 seconds being a default value), while it should say that 0 will set the timeout to default.
